### PR TITLE
activate-mutable: fix auto-update of previous generation

### DIFF
--- a/checks/default.nix
+++ b/checks/default.nix
@@ -1,4 +1,8 @@
 {self, ...}: {
+  imports = [
+    ./tests
+  ];
+
   perSystem = {pkgs, ...}: {
     checks = let
       # Make a check that will succeed if the script exits 0, and fail otherwise.

--- a/checks/tests/activate-mutable/auto-update.nix
+++ b/checks/tests/activate-mutable/auto-update.nix
@@ -33,8 +33,18 @@
           cmp $homeDir/test-file-write $2
         }
 
+        # Run 1: File A must be installed to home (hmf)
         runMutation ${configA.json} ${configA.file}
+        # Run 2: New config with different config and different contents for hmf
+        # hmf contents should be overwritten with File B as hmf starts with identical
+        # contents to Config A's hmf spec
         runMutation ${configB.json} ${configB.file}
+
+        # Run 3 & 4: activation should fail as hmf contents differ from both old
+        # and new configs
+        echo "Something new" >> $homeDir/test-file-write
+        ! ${activate-mutable} activate ${configA.json} $homeDir
+        ! ${activate-mutable} activate ${configB.json} $homeDir
 
         touch $out
       '';

--- a/checks/tests/activate-mutable/auto-update.nix
+++ b/checks/tests/activate-mutable/auto-update.nix
@@ -1,0 +1,42 @@
+{lib, ...}: {
+  perSystem = {
+    self',
+    pkgs,
+    ...
+  }: {
+    checks.activate-mutable-auto-update = let
+      activate-mutable = lib.getExe self'.packages.activate-mutable;
+
+      mkConfig = contents: rec {
+        file = pkgs.writeText "test-file" contents;
+        json = pkgs.writeText "config.json" (builtins.toJSON [
+          {
+            source = file;
+            destination = "test-file-write";
+            onConflict = "warn";
+          }
+        ]);
+      };
+
+      configA = mkConfig "First test file";
+      configB = mkConfig "Second test file";
+    in
+      pkgs.runCommand "activate-mutable-auto-update" {} ''
+        homeDir=$(mktemp --directory)
+        mkdir $homeDir/.config
+
+        runMutation() {
+          ${activate-mutable} activate $1 $homeDir
+          echo "expect: current config written to home"
+          cmp $homeDir/.config/activate-mutable-config.json $1
+          echo "expect: current config's file written if unchanged from previous generation"
+          cmp $homeDir/test-file-write $2
+        }
+
+        runMutation ${configA.json} ${configA.file}
+        runMutation ${configB.json} ${configB.file}
+
+        touch $out
+      '';
+  };
+}

--- a/checks/tests/activate-mutable/default.nix
+++ b/checks/tests/activate-mutable/default.nix
@@ -1,0 +1,5 @@
+{
+  imports = [
+    ./auto-update.nix
+  ];
+}

--- a/checks/tests/default.nix
+++ b/checks/tests/default.nix
@@ -1,0 +1,5 @@
+{
+  imports = [
+    ./activate-mutable
+  ];
+}

--- a/packages/activate-mutable/default.nix
+++ b/packages/activate-mutable/default.nix
@@ -4,7 +4,7 @@
 }:
 rustPlatform.buildRustPackage rec {
   pname = "activate-mutable";
-  version = "3.0.1";
+  version = "3.0.2";
   src = ./.;
 
   cargoLock.lockFile = ./Cargo.lock;

--- a/packages/activate-mutable/src/config.rs
+++ b/packages/activate-mutable/src/config.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -62,14 +62,14 @@ pub fn resolve_directory(
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Deserialize, Debug)]
 #[serde(rename_all = "lowercase")]
 pub enum ConflictStrategy {
     Replace,
     Warn,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 #[serde(rename_all = "camelCase")]
 pub struct ConfigEntry {


### PR DESCRIPTION
Previous generation files were not being auto-updated as `activate-mutable-config.json` was being overwritten by the new config before being read.

Added test cases to check for regressions