### PR TITLE
26#tycho: server: add btrfs external hard drive

### DIFF
--- a/hosts/tycho/hardware-configuration.nix
+++ b/hosts/tycho/hardware-configuration.nix
@@ -19,6 +19,10 @@
     device = "/dev/disk/by-uuid/44444444-4444-4444-8888-888888888888";
     fsType = "ext4";
   };
+  fileSystems."/mnt/extern" = {
+    device = "/dev/disk/by-uuid/480fd0ec-5167-4163-a86e-5edf112961c4";
+    fsType = "btrfs";
+  };
 
   fileSystems."/boot/firmware" = {
     device = "/dev/disk/by-uuid/2175-794E";


### PR DESCRIPTION
Generation  Build-date           NixOS version                                                                     Kernel   Configuration Revision  Specialisation  Current
26          2025-08-05 21:19:41  25.11.20250802.31e6124                                                            6.12.25  Unknown                 []              True

<<< /run/current-system
>>> result
Selection state changes:
[C+]  #1  btrfs-progs  6.15
Closure size: 746 -> 746 (26 paths added, 26 paths removed, delta +0, disk usage +24.9KiB).