### PR TITLE
backup: update exclude lists

### DIFF
--- a/hosts/tycho/configuration.nix
+++ b/hosts/tycho/configuration.nix
@@ -88,13 +88,6 @@
       password = "backup/password";
       destination.local = "/mnt/extern/restic";
       destination.remote = "backup/remote";
-      exclude = [
-        "trilium/log" # Nothing we strongly care about
-        # Daily copy-paste backups of the database
-        # Since we're using a btrfs snapshot, SQLite can recover using
-        # the WAL at any point in time and there is no race condition
-        "trilium/backup"
-      ];
 
       # Creating btrfs snapshots requires root privileges
       owner = "root";

--- a/modules/nixos/backup.nix
+++ b/modules/nixos/backup.nix
@@ -128,6 +128,17 @@
         };
       });
     };
+
+    # TODO: Browse redu and add anything that should be excluded
+    defaultExclusions = mkOption {
+      type = types.listOf types.str;
+      default = [];
+      description = ''
+        A list of patterns to exclude from all backups.
+
+        See [Backing up - Excluding Files](https://restic.readthedocs.io/en/latest/040_backup.html#excluding-files) for more information.
+      '';
+    };
   };
 
   config = let
@@ -167,7 +178,7 @@
           then "${cfgr.btrfs.snapshotPath}/${tmpname}"
           else cfgr.source;
       in {
-        inherit (cfgr) exclude;
+        exclude = cfgr.exclude ++ cfg.defaultExclusions;
         user = cfgr.owner;
         paths = [finalPath];
 

--- a/modules/nixos/backup.nix
+++ b/modules/nixos/backup.nix
@@ -16,6 +16,26 @@
         '';
         type = types.int;
       };
+
+    mkExcludeOption = scope: mkOption {
+      description = ''
+        A list of patterns to exclude from ${scope}.
+
+        See [Backing up - Excluding Files](https://restic.readthedocs.io/en/latest/040_backup.html#excluding-files) for more information.
+
+        WARN: Absolute paths are not supported in combination with btrfs snapshots,
+        as the snapshot is created in a different directory and therefore will not
+        match such patterns.
+      '';
+
+      type = types.listOf types.str;
+      default = [];
+      example = [
+        ".git"
+        "node_modules"
+        "already-in-git"
+      ];
+    };
   in {
     repositories = mkOption {
       description = ''
@@ -47,21 +67,7 @@
             example = "/home/bob/Documents";
           };
 
-          exclude = mkOption {
-            description = ''
-              A list of patterns to exclude from the backup.
-
-              See [Backing up - Excluding Files](https://restic.readthedocs.io/en/latest/040_backup.html#excluding-files) for more information.
-            '';
-
-            type = types.listOf types.str;
-            default = [];
-            example = [
-              ".git"
-              "node_modules"
-              "already-in-git"
-            ];
-          };
+          exclude = mkExcludeOption "the backup";
 
           destination.local = mkOption {
             description = ''
@@ -130,15 +136,7 @@
     };
 
     # TODO: Browse redu and add anything that should be excluded
-    defaultExclusions = mkOption {
-      type = types.listOf types.str;
-      default = [];
-      description = ''
-        A list of patterns to exclude from all backups.
-
-        See [Backing up - Excluding Files](https://restic.readthedocs.io/en/latest/040_backup.html#excluding-files) for more information.
-      '';
-    };
+    defaultExclusions = mkExcludeOption "all backups";
   };
 
   config = let

--- a/modules/nixos/backup.nix
+++ b/modules/nixos/backup.nix
@@ -135,7 +135,6 @@
       });
     };
 
-    # TODO: Browse redu and add anything that should be excluded
     defaultExclusions = mkExcludeOption "all backups";
   };
 

--- a/modules/nixos/server/immich.nix
+++ b/modules/nixos/server/immich.nix
@@ -74,12 +74,12 @@
         };
       };
 
-      # Workaround for https://github.com/nixos/nixpkgs/issues/418799
-      # needed for machine-learning to download models
-      users.users.immich = {
-        home = "/var/lib/immich";
-        createHome = true;
-      };
+      custom.backup.defaultExclusions = [
+        # These are derived from source photos/videos. Excluding them
+        # saves ~5% space.
+        "immich/thumbs"
+        "immich/encoded-video"
+      ];
 
       services.immich = {
         enable = true;

--- a/modules/nixos/server/minecraft.nix
+++ b/modules/nixos/server/minecraft.nix
@@ -68,6 +68,15 @@
         };
       };
 
+      custom.backup.defaultExclusions = [
+        # No need to backup logs
+        "minecraft/*/logs"
+        # Fetched at runtime
+        "minecraft/*/libraries"
+        "minecraft/*/.fabric"
+        "minecraft/*/versions"
+      ];
+
       # Command to start server if it isn't already running, and connects to its console
       # To exit, use `Ctrl+b, d`
       # TODO: Remove once https://github.com/Infinidoge/nix-minecraft/issues/166 is resolved

--- a/modules/nixos/server/paperless.nix
+++ b/modules/nixos/server/paperless.nix
@@ -50,6 +50,10 @@
         };
       };
 
+      custom.backup.defaultExclusions = [
+        "paperless/media/documents/thumbnails/"
+      ];
+
       services.paperless = {
         inherit (cfgp) dataDir;
         enable = true;

--- a/modules/nixos/server/search.nix
+++ b/modules/nixos/server/search.nix
@@ -79,6 +79,17 @@
           modules = builtins.attrValues inputs.sops-nix.nixosModules;
           urlPrefix = "https://github.com/Mic92/sops-nix";
         }
+        {
+          name = "Minecraft";
+          modules = builtins.attrValues inputs.nix-minecraft.nixosModules;
+          urlPrefix = "https://github.com/Infinidoge/nix-minecraft";
+        }
+        # FIXME: Same issue as stylix
+        # {
+        #   name = "Copyparty";
+        #   modules = builtins.attrValues inputs.copyparty.nixosModules;
+        #   urlPrefix = "https://github.com/9001/copyparty";
+        # }
       ];
 
       subdomains = {

--- a/modules/nixos/server/trilium.nix
+++ b/modules/nixos/server/trilium.nix
@@ -126,6 +126,15 @@
           };
         };
 
+        custom.backup.defaultExclusions = [
+          # Nothing we strongly care about
+          "trilium/log"
+          # Daily copy-paste backups of the database
+          # Since we're using a btrfs snapshot, SQLite can recover using
+          # the WAL at any point in time and there is no race condition
+          "trilium/backup"
+        ];
+
         services.trilium-server = {
           enable = true;
           port = cfg.ports.tcp.trilium;


### PR DESCRIPTION
Exclude generated or non-essential files from backups. This saves ~5% disk usage.

```
to repack:        160981 blobs / 10.396 GiB
this removes:     127708 blobs / 2.675 GiB
to delete:         62242 blobs / 13.065 GiB
total prune:      189950 blobs / 15.740 GiB
remaining:        219900 blobs / 231.195 GiB
unused size after prune: 0 B (0.00% of remaining size)
```